### PR TITLE
Create view of identification page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -22,3 +22,4 @@
 @import "modules/posts/index.scss";
 @import 'modules/mypage/mypage_main';
 @import 'modules/mypage/logout';
+@import 'modules/mypage/identification';

--- a/app/assets/stylesheets/modules/mypage/identification.scss
+++ b/app/assets/stylesheets/modules/mypage/identification.scss
@@ -1,0 +1,138 @@
+.user-registration-info {
+
+  &__title {
+    padding: 8px 24px;
+    text-align: center;
+    font-size: 24px;
+    border-bottom: 2px solid #eee;
+    h1 {
+      font-weight: bold;
+    }
+  }
+
+  &__content {
+    .user-registration-info-form {
+      
+      &__description {
+        width: 100%;
+        margin-top: 15px;
+        padding: 45px 0;
+        text-align: center;
+        font-size: 14px;
+        &--register {
+          margin-top: 0;
+          padding-top: 0;
+        }
+        p {
+          width: 85%;
+          text-align: left;
+          display: inline-block;
+        }
+        .about-upload-info {
+          width: 100%;
+          margin-top: 5px;
+          padding-right: 60px;
+          text-align: right;
+          display: inline-block;
+          a {
+            color: $guide_links;
+          }
+          a:hover {
+            opacity: $guide_links_opacity;
+            text-decoration: underline;
+          }
+        }
+      }
+  
+      .registration-form-group {
+        width: 85%;
+        margin: 0 auto;
+        padding-bottom: 40px;
+
+        p {
+          font-size: 14px;
+        }
+
+        &__label {
+          font-weight: 600;
+          font-size: 14px;
+        }
+
+        &__text-field {
+          width: 100%;
+          margin: 5px 0;
+          padding: 10px 16px 8px;
+          border-radius: 4px;
+          border: 1px solid #ccc;
+          outline: none;
+          &--number-field {
+            width: 20%;
+          }
+        }
+        &__text-field:focus {
+          border: 1px solid $guide_links;
+        }
+
+        &__require-badge {
+          padding: 3px 4px;
+          border-radius: 2px;
+          font-size: $require_badge;
+          color: $badge_font_color;
+          background-color: #ea352d;
+          &--optional {
+            background-color: #ccc;
+          }
+        }
+
+        &__birthday {
+          width: 100%;
+          display: flex;
+          align-items: center;
+          position: relative;
+          .drop-down-arrow-icon {
+            position: absolute;
+            right: 86%;
+            bottom: 0;
+            top: 32%;
+            color: #bdbdbd;
+          }
+          .registration-form-unit {
+            margin-left: 5px;
+            font-size: 14px;
+            color: #888;
+          }
+        }
+
+        .registration-form-caution {
+          margin-top: 5px;
+          font-size: 14px;
+          color: #888;
+        }
+
+        &--prefecture {
+          position: relative;
+          .drop-down-arrow-icon {
+            position: absolute;
+            top: 35%;
+            bottom: 0;
+            right: 2%;
+            color: #bdbdbd;
+          }
+        }
+
+        &__register-btn {
+          width: 100%;
+          padding: 15px 0;
+          border: none;
+          outline: none;
+          color: $btn_font_color;
+          background-color: $red_btn;
+          cursor: pointer;
+        }
+        &__register-btn:hover {
+          background-color: $red_btn_hover;
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -4,4 +4,7 @@ class MypagesController < ApplicationController
 
   def logout
   end
+
+  def identification
+  end
 end

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -1,0 +1,131 @@
+= render "shared/top_page/header"
+
+.main-body
+  = render partial: 'shared/mypage/side_menu'
+
+  .mypage-main
+    .mypage-main-top.user-registration-info
+      .user-registration-info__title
+        %h1 本人情報の登録
+      .user-registration-info__content
+        = form_with url: '#', class: 'user-registration-info-form' do |f|
+          .user-registration-info-form__description
+            %p 
+              お客様の本人情報をご登録ください。
+              %br
+              登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
+            %p.about-upload-info
+              = link_to '#' do
+                本人確認書類のアップロードについて
+                = icon('fas', 'chevron-right')
+
+          -# 名前、生年月日等が登録済みの場合
+          .registration-form-group
+            = f.label 'お名前', class: 'registration-form-group__label'
+            %p 山田 彩
+          .registration-form-group
+            = f.label 'お名前カナ', class: 'registration-form-group__label'
+            %p ヤマダ アヤ
+          .registration-form-group
+            = f.label '生年月日', class: 'registration-form-group__label'
+            %p 1992/05/07
+          .registration-form-group
+            = f.label '郵便番号', class: 'registration-form-group__label'
+            %span.registration-form-group__require-badge.registration-form-group__require-badge--optional 任意
+            %br
+            = f.text_field :postal_code, placeholder: '例）1234567', class: 'registration-form-group__text-field', value: "1234567"
+          .registration-form-group.registration-form-group--prefecture
+            = f.label '都道府県', class: 'registration-form-group__label'
+            %span.registration-form-group__require-badge.registration-form-group__require-badge--optional 任意
+            %br
+            = f.text_field :prefecture, placeholder: '--', class: 'registration-form-group__text-field', value: "神奈川県"
+            .drop-down-arrow-icon
+              = icon('fas', 'chevron-down')
+          .registration-form-group
+            = f.label '市区町村', class: 'registration-form-group__label'
+            %span.registration-form-group__require-badge.registration-form-group__require-badge--optional 任意
+            %br
+            = f.text_field :city, placeholder: '例) 横浜市緑区', class: 'registration-form-group__text-field', value: "横浜市緑区"
+          .registration-form-group
+            = f.label '番地', class: 'registration-form-group__label'
+            %span.registration-form-group__require-badge.registration-form-group__require-badge--optional 任意
+            %br
+            = f.text_field :block, placeholder: '例) 青山1−1−1', class: 'registration-form-group__text-field', value: "青山1-1-1"
+          .registration-form-group
+            = f.label '建物名', class: 'registration-form-group__label'
+            %span.registration-form-group__require-badge.registration-form-group__require-badge--optional 任意
+            %br
+            = f.text_field :building, placeholder: '例) 柳ビル103', class: 'registration-form-group__text-field', value: "柳ビル103"
+
+          -# 名前、生年月日等を登録していない人には以下のコメントアウト部分を表示
+          -# .registration-form-group
+          -#   = f.label 'お名前', class: 'resistration-form-group__label'
+          -#   %span.registration-form-group__require-badge 必須
+          -#   %br
+          -#   = f.text_field :family_name, placeholder: '例）山田', class: 'registration-form-group__text-field'
+          -#   %br
+          -#   = f.text_field :first_name, placeholder: '例）彩', class: 'registration-form-group__text-field'
+          -# .registration-form-group
+          -#   = f.label 'お名前カナ', class: 'resistration-form-group__label'
+          -#   %span.registration-form-group__require-badge 必須
+          -#   %br
+          -#   = f.text_field :family_name_kana, placeholder: '例）ヤマダ', class: 'registration-form-group__text-field'
+          -#   %br
+          -#   = f.text_field :first_name_kana, placeholder: '例）アヤ', class: 'registration-form-group__text-field'
+          -# .registration-form-group
+          -#   = f.label '生年月日', class: 'resistration-form-group__label'
+          -#   %span.registration-form-group__require-badge 必須
+          -#   .registration-form-group__birthday
+          -#     = f.number_field :birth_year, placeholder: '--', class: 'registration-form-group__text-field registration-form-group__text-field--number-field'
+          -#     .drop-down-arrow-icon
+          -#       = icon('fas', 'chevron-down')
+          -#     %p.registration-form-unit 年
+          -#   .registration-form-group__birthday
+          -#     = f.number_field :birth_month, placeholder: '--', class: 'registration-form-group__text-field registration-form-group__text-field--number-field'
+          -#     .drop-down-arrow-icon
+          -#       = icon('fas', 'chevron-down')
+          -#     %p.registration-form-unit 月
+          -#   .registration-form-group__birthday
+          -#     = f.number_field :birth_day, placeholder: '--', class: 'registration-form-group__text-field registration-form-group__text-field--number-field'
+          -#     .drop-down-arrow-icon
+          -#       = icon('fas', 'chevron-down')
+          -#     %p.registration-form-unit 日
+          -#   %p.registration-form-caution ※出品されたことがある、本人情報未登録のお客さまもご対象となります。
+          -# .registration-form-group
+          -#   = f.label '郵便番号', class: 'resistration-form-group__label'
+          -#   %span.registration-form-group__require-badge.registration-form-group__require-badge--optional 任意
+          -#   %br
+          -#   = f.text_field :postal_code, placeholder: '例）1234567', class: 'registration-form-group__text-field'
+          -# .registration-form-group.registration-form-group--prefecture
+          -#   = f.label '都道府県', class: 'resistration-form-group__label'
+          -#   %span.registration-form-group__require-badge.registration-form-group__require-badge--optional 任意
+          -#   %br
+          -#   = f.text_field :prefecture, placeholder: '--', class: 'registration-form-group__text-field'
+          -#   .drop-down-arrow-icon
+          -#     = icon('fas', 'chevron-down')
+          -# .registration-form-group
+          -#   = f.label '市区町村', class: 'resistration-form-group__label'
+          -#   %span.registration-form-group__require-badge.registration-form-group__require-badge--optional 任意
+          -#   %br
+          -#   = f.text_field :city, placeholder: '例) 横浜市緑区', class: 'registration-form-group__text-field'
+          -# .registration-form-group
+          -#   = f.label '番地', class: 'resistration-form-group__label'
+          -#   %span.registration-form-group__require-badge.registration-form-group__require-badge--optional 任意
+          -#   %br
+          -#   = f.text_field :block, placeholder: '例) 青山1−1−1', class: 'registration-form-group__text-field'
+          -# .registration-form-group
+          -#   = f.label '建物名', class: 'resistration-form-group__label'
+          -#   %span.registration-form-group__require-badge.registration-form-group__require-badge--optional 任意
+          -#   %br
+          -#   = f.text_field :building, placeholder: '例) 柳ビル103', class: 'registration-form-group__text-field'
+          .registration-form-group
+            = f.submit '登録する', class: 'registration-form-group__register-btn'
+          .user-registration-info-form__description.user-registration-info-form__description--register
+            %p.about-upload-info.about-upload-info--register
+              = link_to '#' do
+                本人情報の登録について
+                = icon('fas', 'chevron-right')
+
+= render "shared/top_page/sell-fix-logo"
+= render "shared/top_page/app-banner"
+= render "shared/top_page/footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resources :mypages, only: :index do
     collection do
       get 'logout'
+      get 'identification'
     end
   end
   root 'posts#index'


### PR DESCRIPTION
# What
ユーザー本人確認ページを実装する

本人情報登録済みの場合１
https://gyazo.com/7eace69d207e06ac3acb655c9a005c6f

本人情報登録済みの場合２
https://gyazo.com/1c1b83b009cd74a3f70f24053a1205e4

本人情報未登録の場合１(コード内ではコメントアウト中)
https://gyazo.com/fec5ed8cddd6d79195ef5b084ab9c834

本人情報未登録の場合２(コード内ではコメントアウト中)
https://gyazo.com/4a4e0518e3c1381cc28d0b2e5fa0f754

本人情報未登録の場合３(コード内ではコメントアウト中)
https://gyazo.com/468965ce7f177a68ecf19bddf3eddecf

# Why
ユーザー本人確認ページを表示できるようにするため