### PR TITLE
Create-image-upload-function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 /public/assets
 .byebug_history
 
-/public/uploads/image/image
+/public/uploads/
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@
 /public/assets
 .byebug_history
 
+/public/uploads/image/image
+
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 .byebug_history

--- a/app/assets/stylesheets/modules/shared/posts_new/image_upload.scss
+++ b/app/assets/stylesheets/modules/shared/posts_new/image_upload.scss
@@ -1,5 +1,4 @@
 .post__upload__box{
-  width: 620px;
   padding: 40px;
   .post__upload__head{
     font-weight: bold;
@@ -13,42 +12,38 @@
   }
   .post__drop__box__container{
     display: block;
-    width: 620px;
     margin: 16px auto 0;
     .post__upload__items__container__items{
-      display: inline; 
-      &__item{
-        display: block;
-        float: left;
-        ul{
-          display: block;
-          width: 100%;
+      .hidden-boxes {
+        display: flex;
+        border: 1px dashed #ccc;
+        box-sizing: border-box;
+        margin-bottom: 10px;
+        position: relative;
+        background: #f5f5f5;
+        .text-visible {
+          position: absolute;
+          top: 50%;
+          left: 16px;
+          right: 16px;
+          text-align: center;
+          font-size: 14px;
+          line-height: 1.5;
+          font-weight: bold;
+          -webkit-transform: translate(0, -50%);
+          transform: translate(0, -50%);
+          pointer-events: none;
+          white-space: pre-wrap;
+          word-wrap: break-word;
         }
-      }
-    }
-    .post__drop__box{
-      width: 100%;
-      margin-left: 0;
-      position: relative;
-      min-height: 162px;
-      background: #f5f5f5;
-      border: 1px dashed #ccc;
-      font-size: 0;
-      text-align: center;
-      cursor: pointer;
-      &__file{
-        border: 0;
-        outline: 0;
-        font-family: inherit;
-      }
-      .text-visible{
-        position: absolute;
-        top: 50%;
-        left: 16px;
-        right: 16px;
-        text-align: center;
-        font-size: 14px;
-        line-height: 1.5;
+        .hidden-box {
+          width: 124px;
+          height: 160px;
+          cursor: pointer;
+        }
+        .hidden-field {
+          display: none;
+        }
       }
     }
   }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
-    10.times { @post.images.build }
+    5.times { @post.images.build }
   end
 
   def create

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,12 +4,13 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
+    10.times { @post.images.build }
   end
 
   def create
     @post = Post.new(post_params)
     if @post.save
-      redirect_to 'root_path', notice: '出品が完了しました'
+      redirect_to @post, notice: '出品が完了しました'
       # パスは仮置き
     else
       render :new
@@ -39,6 +40,7 @@ class PostsController < ApplicationController
                                  :delivery_date,
                                  :product_price,
                                  :user_id,
+                                 [images_attributes: [:image]]
                                  ).merge(user_id: current_user.id)
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,2 @@
+class Image < ApplicationRecord
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,2 +1,3 @@
 class Image < ApplicationRecord
+  belongs_to :post
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,3 +1,4 @@
 class Image < ApplicationRecord
   belongs_to :post
+  mount_uploader :image, ImageUploader
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,6 +3,7 @@ class Post < ApplicationRecord
   #   belongs_to_active_hash :prefecture
   belongs_to :user
   has_many :images
+  accepts_nested_attributes_for :images
 
   enum product_size:{ xxs_or_less: 0, xs: 1, small: 2, middle: 3, large: 4, xl: 5, xxl: 6, xxxl: 7, xxxxl_or_more: 8, free: 9 }
   enum product_condition:{ cond_s: 0, cond_a: 1, cond_b: 2, cond_c: 3, cond_d: 4, cond_e: 5 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,6 +2,7 @@ class Post < ApplicationRecord
   # extend ActiveHash::Associations::ActiveRecordExtensions
   #   belongs_to_active_hash :prefecture
   belongs_to :user
+  has_many :images
 
   enum product_size:{ xxs_or_less: 0, xs: 1, small: 2, middle: 3, large: 4, xl: 5, xxl: 6, xxxl: 7, xxxxl_or_more: 8, free: 9 }
   enum product_condition:{ cond_s: 0, cond_a: 1, cond_b: 2, cond_c: 3, cond_d: 4, cond_e: 5 }

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,11 +1,11 @@
 class ImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  # storage :file
-  storage :fog
+  storage :file
+  # storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
@@ -32,7 +32,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # version :thumb do
   #   process resize_to_fit: [50, 50]
   # end
-  process resize_to_fit: [500, 500]
+  process resize_to_fit: [213, 213]
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:

--- a/app/views/shared/posts_new/_image_upload.html.haml
+++ b/app/views/shared/posts_new/_image_upload.html.haml
@@ -5,9 +5,11 @@
   %p 最大10枚までアップロードできます
   .post__drop__box__container
     .post__upload__items__container__items
-      .post__upload__items__container__items__item
-        %ul
-    .post__drop__box
-      =f.file_field :image, class: "post__drop__box__file"
-      %pre.text-visible ドラッグアンドドロップまたはクリックしてファイルをアップロード
-      %i.fas.fa-camera
+      %ul.hidden-boxes
+        %pre.text-visible
+          ドラッグアンドドロップ
+          またはクリックしてファイルをアップロード
+        = f.fields_for :images do |image|
+          = image.label :image do
+            %li.hidden-box
+          = image.file_field :image , class: "hidden-field"

--- a/db/migrate/20190702044212_create_images.rb
+++ b/db/migrate/20190702044212_create_images.rb
@@ -1,0 +1,9 @@
+class CreateImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :images do |t|
+      t.string :image ,null: false
+      t.references :post, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_30_080933) do
-ActiveRecord::Schema.define(version: 2019_06_30_072422) do
+ActiveRecord::Schema.define(version: 2019_07_02_044212) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -43,7 +42,7 @@ ActiveRecord::Schema.define(version: 2019_06_30_072422) do
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "image", null: false
-    t.bigint "post_id", null: false
+    t.bigint "post_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_images_on_post_id"
@@ -97,9 +96,9 @@ ActiveRecord::Schema.define(version: 2019_06_30_072422) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "images", "posts"
   add_foreign_key "addresses", "users"
   add_foreign_key "credit_cards", "users"
+  add_foreign_key "images", "posts"
   add_foreign_key "posts", "brands"
   add_foreign_key "posts", "users"
   add_foreign_key "profiles", "users"


### PR DESCRIPTION
# WHAT
商品出品の画像投稿機能を実装した。
- imageモデル、テーブルの作成
- コントローラーのnewアクションにbuildを記述
- アソシエーション、フォームのネストをmodelに記述
- ストロングパラメーターに画像を追加
- ビューファイル、スタイルの編集
- gitignoreの編集

# WHY
postをcreateした時にimageテーブルにもデータを保存できるようにするため。