### PR TITLE
Add error messages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,6 +50,7 @@
 @import "modules/shared/posts_new/delivery_detail.scss";
 @import "modules/shared/posts_new/price_detail.scss";
 @import "modules/shared/posts_new/post_btn.scss";
+@import "modules/shared/posts_new/error.scss";
 
 @import 'config/profiles/edit_profile';
 @import 'config/profiles/member_info';

--- a/app/assets/stylesheets/modules/shared/posts_new/error.scss
+++ b/app/assets/stylesheets/modules/shared/posts_new/error.scss
@@ -1,0 +1,4 @@
+.error-message {
+  color: #ff0000;
+  padding-top: 5px;
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,7 +12,6 @@ class PostsController < ApplicationController
   end
 
   def create
-    # binding.pry
     @post = Post.new(post_params)
     
     if @post.save

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,67 +4,52 @@ class Post < ApplicationRecord
   belongs_to :user
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images
-  
-  with_options presence: true do
-    validates :images
-    validates :product_name
-    validates :product_description
-    validates :first_category_id
-    validates :second_category_id
-    validates :product_condition
-    validates :delivery_fee
-    validates :delivery_former_area
-    validates :delivery_date
-    validates :product_price
+
+  validate :add_error_message
+ 
+  def add_error_message
+    if images.blank?
+      errors[:images] << "がありません"
+    end
+
+    if product_name.blank?
+      errors[:product_name] << "を入力して下さい"
+    end
+
+    if product_description.blank?
+      errors[:product_description] << "を入力して下さい"
+    end
+
+    if first_category_id.blank?
+      errors[:first_category_id] << "選択して下さい"
+    end
+
+    if second_category_id.blank?
+      errors[:second_category_id] << "選択して下さい"
+    end
+
+    if product_condition.blank?
+      errors[:product_condition] << "選択して下さい"
+    end
+
+    if delivery_fee.blank?
+      errors[:delivery_fee] << "選択して下さい"
+    end
+
+    if delivery_former_area.blank?
+      errors[:delivery_former_area] << "選択して下さい"
+    end
+
+    if delivery_date.blank?
+      errors[:delivery_date] << "選択して下さい"
+    end
+
   end
 
-  validates :product_price, numericality: { only_integer: true, greater_than_or_equal_to: 300 , less_than_or_equal_to: 9999999}
-
-  # validate :add_error_sample
- 
-  # def add_error_sample
-  #   if images.blank?
-  #     errors[:images] << "画像がありません"
-  #   end
-
-  #   if product_name.blank?
-  #     errors[:product_name] << "入力して下さい"
-  #   end
- 
-  #   if product_description.blank?
-  #     errors[:product_description] << "入力して下さい"
-  #   end
- 
-  #   if first_category_id.blank?
-  #     errors[:first_category_id] << "選択して下さい"
-  #   end
- 
-  #   if second_category_id.blank?
-  #     errors[:second_category_id] << "選択して下さい"
-  #   end
- 
-  #   if product_condition.blank?
-  #     errors[:product_condition] << "選択して下さい"
-  #   end
-
-  #   if delivery_fee.blank?
-  #     errors[:delivery_fee] << "選択して下さい"
-  #   end
-
-  #   if delivery_former_area.blank?
-  #     errors[:delivery_former_area] << "選択して下さい"
-  #   end
-
-  #   if delivery_date.blank?
-  #     errors[:delivery_date] << "選択して下さい"
-  #   end
-
-  #   if product_price.blank?
-  #     errors[:product_price] << "入力して下さい"
-  #   end
-
-  # end
-
+  validates :product_name, length: { maximum: 40 }
+  validates :product_description, length: { maximum: 1000 }
+  validates :product_price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999}
+  
   enum product_size:{ xxs_or_less: 0, xs: 1, small: 2, middle: 3, large: 4, xl: 5, xxl: 6, xxxl: 7, xxxxl_or_more: 8, free: 9 }
   enum product_condition:{ cond_s: 0, cond_a: 1, cond_b: 2, cond_c: 3, cond_d: 4, cond_e: 5 }
   enum delivery_fee:{ included: 0, cash_on_delivery: 1 }

--- a/app/views/shared/posts_new/_delivery_detail.html.haml
+++ b/app/views/shared/posts_new/_delivery_detail.html.haml
@@ -11,6 +11,7 @@
           = f.select :delivery_fee, Post.delivery_fees_i18n.invert, {prompt: "---"}, {class: "select__box__format"}
           .drop-down-icon
             = icon('fas', 'chevron-down')
+        = render partial: 'shared/posts_new/error', locals: { post: @post, attr: :delivery_fee}
     .form__content__default
       =f.label :delivery_former_area, "発送元の地域"
       %span.require__form 必須
@@ -19,6 +20,7 @@
           = f.collection_select :delivery_former_area, Prefecture.all, :id, :name, {prompt: "---"}, {class: "select__box__format"}
           .drop-down-icon
             = icon('fas', 'chevron-down')
+        = render partial: 'shared/posts_new/error', locals: { post: @post, attr: :delivery_former_area}
     .form__content__default
       =f.label :delivery_date, "発送までの日数"
       %span.require__form 必須
@@ -27,3 +29,4 @@
           = f.select :delivery_date, Post.delivery_dates_i18n.invert, {prompt: "---"}, {class: "select__box__format"}
           .drop-down-icon
             = icon('fas', 'chevron-down')
+        = render partial: 'shared/posts_new/error', locals: { post: @post, attr: :delivery_date}

--- a/app/views/shared/posts_new/_error.html.haml
+++ b/app/views/shared/posts_new/_error.html.haml
@@ -1,0 +1,4 @@
+- if post.errors.any?
+  - post.errors.full_messages_for(attr).each do |message|
+    %p.error-message
+      = message

--- a/app/views/shared/posts_new/_image_upload.html.haml
+++ b/app/views/shared/posts_new/_image_upload.html.haml
@@ -13,3 +13,4 @@
           = image.label :image do
             %li.hidden-box
           = image.file_field :image , class: "hidden-field"
+      = render partial: 'shared/posts_new/error', locals: { post: @post, attr: :images}

--- a/app/views/shared/posts_new/_price_detail.html.haml
+++ b/app/views/shared/posts_new/_price_detail.html.haml
@@ -11,6 +11,7 @@
         .right__input
           %span ￥
           = f.text_field :product_price, placeholder: "例)300", class: "input__format", id: "price_form"
+          = render partial: 'shared/posts_new/error', locals: { post: @post, attr: :product_price}
       %li.clearfix__normal
         .left__label 販売手数料 (10%)
         .right__label#sales_fee -

--- a/app/views/shared/posts_new/_product_detail.html.haml
+++ b/app/views/shared/posts_new/_product_detail.html.haml
@@ -9,10 +9,12 @@
           = f.collection_select :first_category_id, FirstCategory.all, :id, :name, {prompt: "---"}, {class: "select__box__format"}
           .drop-down-icon
             = icon('fas', 'chevron-down')
+        = render partial: 'shared/posts_new/error', locals: { post: @post, attr: :first_category_id}
         .select__box
           = f.collection_select :second_category_id, SecondCategory.all, :id, :name, {prompt: "---"}, {class: "select__box__format"}
           .drop-down-icon
             = icon('fas', 'chevron-down')
+        = render partial: 'shared/posts_new/error', locals: { post: @post, attr: :second_category_id}
         .select__box
           %select.select__box__format
             %option ---
@@ -40,3 +42,4 @@
           = f.select :product_condition, Post.product_conditions_i18n.invert, {prompt: "---"}, {class: "select__box__format"}
           .drop-down-icon
             = icon('fas', 'chevron-down')
+        = render partial: 'shared/posts_new/error', locals: { post: @post, attr: :product_condition}

--- a/app/views/shared/posts_new/_product_upload.html.haml
+++ b/app/views/shared/posts_new/_product_upload.html.haml
@@ -4,7 +4,9 @@
     %span.require__form 必須
     %div
       = f.text_field :product_name, placeholder: "商品名(必須40文字まで)", class: "input__form"
+      = render partial: 'shared/posts_new/error', locals: { post: @post, attr: :product_name}
   .form__content__description
     =f.label :product_description, "商品の説明"
     %span.require__form 必須
     = f.text_area :product_description, placeholder: "商品の説明(必須 1,000文字以内)(色、素材、重さ、定価、注意点など)例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", class: "textarea__form"
+    = render partial: 'shared/posts_new/error', locals: { post: @post, attr: :product_description}

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -43,3 +43,17 @@ ja:
       - :year
       - :month
       - :day
+
+  activerecord:
+    attributes:
+      post:
+        images: "画像"
+        product_name: "商品名"
+        product_description: "商品説明"
+        first_category_id: ""
+        second_category_id: ""
+        product_condition: ""
+        delivery_fee: ""
+        delivery_former_area: ""
+        delivery_date: ""
+        product_price: "値段"


### PR DESCRIPTION
# WHAT
商品出品画面にバリデーションの際のエラーメッセージを追加した。
- メッセージの日本語化
- 部分テンプレート化
- バリデーションの追加

# WHY
- エラーメッセージを分りやすく表示させるため。