### PR TITLE
Create payjp registration delete function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,4 +93,5 @@ gem 'rspec-rails'
 gem 'factory_bot_rails'
 gem 'rails-i18n'
 
+gem 'payjp'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.4)
     dotenv-rails (2.7.4)
       dotenv (= 2.7.4)
@@ -166,6 +168,8 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -206,6 +210,7 @@ GEM
     net-scp (2.0.0)
       net-ssh (>= 2.6.5, < 6.0.0)
     net-ssh (5.2.0)
+    netrc (0.11.0)
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -228,6 +233,8 @@ GEM
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
     orm_adapter (0.5.0)
+    payjp (0.0.6)
+      rest-client (~> 2.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -278,6 +285,10 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec-core (3.8.1)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
@@ -342,6 +353,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
     unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -392,6 +406,7 @@ DEPENDENCIES
   omniauth
   omniauth-facebook
   omniauth-google-oauth2
+  payjp
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)

--- a/README.md
+++ b/README.md
@@ -53,11 +53,10 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|card_number|integer|null: false, unique: true|
-|expiration_date|integer|null: false|
-|expiration_year|integer|null: false|
-|security_code|integer|null: false|
+
 |user_id|references|null: false, foreign_key: true|
+|costomer_id|integer|null: false|
+|card_id|integer|null: false|
 
 ### Assosiation
 - belongs_to :user

--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,0 +1,33 @@
+document.addEventListener(
+  "DOMContentLoaded", e => {
+    if (document.getElementById("token_submit") != null) { //token_submitというidがnullの場合、下記コードを実行しない
+      Payjp.setPublicKey("pk_test_61fe8dd669a59526fd8542f5"); //ここに公開鍵を直書き
+      let btn = document.getElementById("token_submit"); //IDがtoken_submitの場合に取得されます
+      btn.addEventListener("click", e => { //ボタンが押されたときに作動します
+        e.preventDefault(); //ボタンを一旦無効化します
+        let card = {
+          number: document.getElementById("card_number").value,
+          cvc: document.getElementById("cvc").value,
+          exp_month: document.getElementById("exp_month").value,
+          exp_year: document.getElementById("exp_year").value
+        }; //入力されたデータを取得します。
+        Payjp.createToken(card, (status, response) => {
+          if (status === 200) { //成功した場合
+            $("#card_number").removeAttr("name");
+            $("#cvc").removeAttr("name");
+            $("#exp_month").removeAttr("name");
+            $("#exp_year").removeAttr("name"); //データを自サーバにpostしないように削除
+            $("#card_token").append(
+              $('<input type="hidden" name="payjp-token">').val(response.id)
+            ); //取得したトークンを送信できる状態にします
+            document.inputForm.submit();
+            alert("登録が完了しました"); //確認用
+          } else {
+            alert("カード情報が正しくありません。"); //確認用
+          }
+        });
+      });
+    }
+  },
+  false
+);

--- a/app/controllers/credit_card_controller.rb
+++ b/app/controllers/credit_card_controller.rb
@@ -5,7 +5,7 @@ class CreditCardController < ApplicationController
   end
 
   def registration
-    card = CreditCard.where(user_id: current_user.id)
+    card = current_user.credit_cards
     redirect_to action: "show" if card.exists?
   end
 
@@ -29,9 +29,8 @@ class CreditCardController < ApplicationController
   end
 
   def delete
-    card = CreditCard.where(user_id: current_user.id).first
-    if card.blank?
-    else
+    card = current_user.credit_cards.first
+    unless card.blank?
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
       customer = Payjp::Customer.retrieve(card.customer_id)
       customer.delete
@@ -41,7 +40,7 @@ class CreditCardController < ApplicationController
   end
 
   def show
-    card = CreditCard.where(user_id: current_user.id).first
+    card = current_user.credit_cards.first
     if card.blank?
       redirect_to action: "registration" 
     else

--- a/app/controllers/credit_card_controller.rb
+++ b/app/controllers/credit_card_controller.rb
@@ -30,7 +30,7 @@ class CreditCardController < ApplicationController
 
   def delete
     card = current_user.credit_cards.first
-    unless card.blank?
+    if card.present?
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
       customer = Payjp::Customer.retrieve(card.customer_id)
       customer.delete
@@ -41,12 +41,12 @@ class CreditCardController < ApplicationController
 
   def show
     card = current_user.credit_cards.first
-    if card.blank?
-      redirect_to action: "registration" 
-    else
+    if card.present?
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
       customer = Payjp::Customer.retrieve(card.customer_id)
       @default_card_information = customer.cards.retrieve(card.card_id)
+    else
+      redirect_to action: "registration" 
     end
   end
   

--- a/app/controllers/credit_card_controller.rb
+++ b/app/controllers/credit_card_controller.rb
@@ -1,7 +1,54 @@
 class CreditCardController < ApplicationController
 
   def new
-    
+
+  end
+
+  def registration
+    card = CreditCard.where(user_id: current_user.id)
+    redirect_to action: "show" if card.exists?
+  end
+
+  def pay
+    Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+    if params['payjp-token'].blank?
+      redirect_to action: "registration"
+    else
+      customer = Payjp::Customer.create(
+      email: current_user.email,
+      card: params['payjp-token'],
+      metadata: {user_id: current_user.id}
+      )
+      @card = CreditCard.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
+      if @card.save
+        redirect_to action: "show"
+      else
+        redirect_to action: "pay"
+      end
+    end
+  end
+
+  def delete
+    card = CreditCard.where(user_id: current_user.id).first
+    if card.blank?
+    else
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      customer.delete
+      card.delete
+    end
+      redirect_to action: "registration"
+  end
+
+  def show
+    card = CreditCard.where(user_id: current_user.id).first
+    if card.blank?
+      redirect_to action: "registration" 
+    else
+      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+      customer = Payjp::Customer.retrieve(card.customer_id)
+      @default_card_information = customer.cards.retrieve(card.card_id)
+    end
   end
   
 end

--- a/app/views/credit_card/registration.html.haml
+++ b/app/views/credit_card/registration.html.haml
@@ -1,0 +1,39 @@
+= form_tag(pay_credit_card_index_path, method: :post, id: 'charge-form',  name: "inputForm") do
+  %label カード番号
+  = text_field_tag "number", "", class: "number", placeholder: "半角数字のみ" ,maxlength: "16", type: "text", id: "card_number"
+  %br
+  %label 有効期限
+  %select#exp_month{name: "exp_month", type: "text"}
+    %option{value: ""} --
+    %option{value: "1"}01
+    %option{value: "2"}02
+    %option{value: "3"}03
+    %option{value: "4"}04
+    %option{value: "5"}05
+    %option{value: "6"}06
+    %option{value: "7"}07
+    %option{value: "8"}08
+    %option{value: "9"}09
+    %option{value: "10"}10
+    %option{value: "11"}11
+    %option{value: "12"}12
+  %span 月/
+  %select#exp_year{name: "exp_year", type: "text"}
+    %option{value: ""} --
+    %option{value: "2019"}19
+    %option{value: "2020"}20
+    %option{value: "2021"}21
+    %option{value: "2022"}22
+    %option{value: "2023"}23
+    %option{value: "2024"}24
+    %option{value: "2025"}25
+    %option{value: "2026"}26
+    %option{value: "2027"}27
+    %option{value: "2028"}28
+    %option{value: "2029"}29
+  %span 年
+  %br
+  %label セキュリティコード
+  = text_field_tag "cvc", "", class: "cvc", placeholder: "カード背面3~4桁の番号", maxlength: "4", id: "cvc"
+  #card_token
+  = submit_tag "追加する", id: "token_submit"

--- a/app/views/credit_card/show.html.haml
+++ b/app/views/credit_card/show.html.haml
@@ -1,0 +1,10 @@
+%label 登録クレジットカード情報
+%br
+= "**** **** **** " + @default_card_information.last4
+%br
+- exp_month = @default_card_information.exp_month.to_s
+- exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+= exp_month + " / " + exp_year
+= form_tag(delete_credit_card_index_path, method: :post, id: 'charge-form',  name: "inputForm") do
+  %input{ type: "hidden", name: "card_id", value: "" }
+  %button 削除する

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,7 +7,9 @@
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    %script{src: "https://js.pay.jp/", type: "text/javascript"}
     %link{href: "https://use.fontawesome.com/releases/v5.6.1/css/all.css", rel: "stylesheet"}/
+    
   %body
     
     = yield

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,9 @@ Rails.application.routes.draw do
   
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   resources :posts do
-    collection do
-      get 'buy'
+    member do
+      get 'transaction'
+      post 'buy'
     end
   end
 
@@ -22,7 +23,16 @@ Rails.application.routes.draw do
 
   root 'posts#index'
   
-  resources :credit_card, only: :new
+  resources :credit_card, only: [:new, :show] do
+    collection do
+      get 'registration'
+      post 'show', to: 'credit_card#show'
+      post 'pay', to: 'credit_card#pay'
+      post 'delete', to: 'credit_card#delete'
+    end
+  end
+
+
   resources :address, only: :new
   resources :profiles, only: :new
 

--- a/db/migrate/20190707045841_add_column_to_credit_cards.rb
+++ b/db/migrate/20190707045841_add_column_to_credit_cards.rb
@@ -1,0 +1,6 @@
+class AddColumnToCreditCards < ActiveRecord::Migration[5.2]
+  def change
+    add_column :credit_cards, :customer_id, :string, null: false
+    add_column :credit_cards, :card_id, :string, null: false
+  end
+end

--- a/db/migrate/20190707045841_add_column_to_credit_cards.rb
+++ b/db/migrate/20190707045841_add_column_to_credit_cards.rb
@@ -2,5 +2,9 @@ class AddColumnToCreditCards < ActiveRecord::Migration[5.2]
   def change
     add_column :credit_cards, :customer_id, :string, null: false
     add_column :credit_cards, :card_id, :string, null: false
+    remove_column :credit_cards, :card_number, :integer
+    remove_column :credit_cards, :expiration_date, :integer
+    remove_column :credit_cards, :expiration_year, :integer
+    remove_column :credit_cards, :security_code, :integer
   end
 end

--- a/db/migrate/20190707060350_remove_column_from_credit_cards.rb
+++ b/db/migrate/20190707060350_remove_column_from_credit_cards.rb
@@ -1,0 +1,8 @@
+class RemoveColumnFromCreditCards < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :credit_cards, :card_number, :integer
+    remove_column :credit_cards, :expiration_date, :integer
+    remove_column :credit_cards, :expiration_year, :integer
+    remove_column :credit_cards, :security_code, :integer
+  end
+end

--- a/db/migrate/20190707060350_remove_column_from_credit_cards.rb
+++ b/db/migrate/20190707060350_remove_column_from_credit_cards.rb
@@ -1,8 +1,0 @@
-class RemoveColumnFromCreditCards < ActiveRecord::Migration[5.2]
-  def change
-    remove_column :credit_cards, :card_number, :integer
-    remove_column :credit_cards, :expiration_date, :integer
-    remove_column :credit_cards, :expiration_year, :integer
-    remove_column :credit_cards, :security_code, :integer
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_07_060350) do
+ActiveRecord::Schema.define(version: 2019_07_07_045841) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_04_071524) do
+ActiveRecord::Schema.define(version: 2019_07_07_060350) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -33,8 +33,10 @@ ActiveRecord::Schema.define(version: 2019_07_04_071524) do
   create_table "credit_cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id", null: false
+    t.bigint "user_id"
+    t.string "customer_id", null: false
     t.string "card_id", null: false
+    t.index ["user_id"], name: "index_credit_cards_on_user_id"
   end
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -97,6 +99,7 @@ ActiveRecord::Schema.define(version: 2019_07_04_071524) do
   end
 
   add_foreign_key "addresses", "users"
+  add_foreign_key "credit_cards", "users"
   add_foreign_key "images", "posts"
   add_foreign_key "posts", "brands"
   add_foreign_key "posts", "users"


### PR DESCRIPTION
# WHAT
Payjp クレジットカード登録削除機能を実装

### 完了
- テストモードを使用して、クレジット情報の登録削除機能の実装
- payjpの画面
<img width="1280" alt="スクリーンショット 2019-07-07 15 44 37" src="https://user-images.githubusercontent.com/42095725/60765061-025f8680-a0cf-11e9-886e-bf46bccd6b56.png">

- Sequel Pro の CreditCardの画面
<img width="864" alt="スクリーンショット 2019-07-07 15 47 21" src="https://user-images.githubusercontent.com/42095725/60765050-e360f480-a0ce-11e9-9d84-a836c97ece27.png">

https://gyazo.com/7c2f3ea2b54573b0a642d525f14030c4
### 未完了
- ビューの見た目は現在仮置きで作成している
  　→メルカリ仕様に変更する必要がある
- 購入は未実装

# WHY
商品購入するためには、
クレジット情報をpayjpで登録する必要があるため


