### PR TITLE
Set link in side menu of telephone confirmation

### DIFF
--- a/app/views/shared/mypage/_side_menu.html.haml
+++ b/app/views/shared/mypage/_side_menu.html.haml
@@ -142,7 +142,7 @@
           .list-arrow-icon
             = icon('fas', 'chevron-right')
       %li.menu-list
-        = link_to '#', class: 'menu-link' do
+        = link_to telephone_number_mypages_path, class: 'menu-link' do
           .menu-text
             電話番号の確認
           .list-arrow-icon


### PR DESCRIPTION
# What
サイドメニューから電話番号確認ページに遷移できるようにパスを設定

# Why
本物のメルカリの仕様と合わせるため