### PR TITLE
Fix view of mypage

### DIFF
--- a/app/assets/stylesheets/mixins/mypage/tabs.scss
+++ b/app/assets/stylesheets/mixins/mypage/tabs.scss
@@ -7,7 +7,9 @@
       width: 50%;
       text-align: center;
       line-height: 60px;
-      font-weight: bold;
+      &__name {
+        font-weight: bold;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/modules/mypage/mypage_main.scss
+++ b/app/assets/stylesheets/modules/mypage/mypage_main.scss
@@ -21,7 +21,7 @@ a {
 }
 
 .user-header {
-  background-image: url("mypage/user-header.jpg");
+  background-image: image-url("mypage/user-header.jpg");
   background-size: cover;
   height: 200px;
   a {
@@ -83,6 +83,9 @@ a {
   @include tab_style();
   .tabs-list {
     cursor: pointer;
+    a {
+      color: #333;
+    }
     &__news {
       border-top: 2px solid #d32f2f;
     }
@@ -115,10 +118,12 @@ a {
     .contents-list {
       a {
         @include link_style(80px);
+        color: #333;
         .contents-list-main {
           width: 85%;
           font-size: $links_font;
           &__bottom {
+            margin-top: 5px;
             .bottom-lists {
               display: flex;
               color: #9e9e9e;
@@ -146,6 +151,9 @@ a {
       height: 80px;
       border-bottom: 1px solid #eee;
       position: relative;
+      a {
+        color: #333;
+      }
       &__box {
         // $widthと$heightの値を指定して呼び出し
         @include position_absolute($width: 95%, $height: 65%);
@@ -176,7 +184,7 @@ a {
   .no-content-box {
     height: 100%;
     width: 100%;
-    background-image: url('mypage/no-content.png');
+    background-image: image-url('mypage/no-content.png');
     background-size: 15%;
     background-position: 50% 30%;
     background-repeat: no-repeat;
@@ -186,13 +194,13 @@ a {
       font-weight: bold;
       &--to-do {
         // top, left, width, heightの順で値の指定が可能
-        @include position_absolute(90%, 18%, 50%, 60%);
+        @include position_absolute(95%, 22%, 50%, 60%);
       }
       &--in-transaction {
-        @include position_absolute(90%, 24%, 50%, 60%);
+        @include position_absolute(95%, 27%, 50%, 60%);
       }
       &--past-trading {
-        @include position_absolute(90%, 25%, 50%, 60%);
+        @include position_absolute(95%, 29%, 50%, 60%);
       }
     }
   }

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,6 +1,6 @@
 class MypagesController < ApplicationController
   before_action :get_user_has_posts, only: [:purchase, :purchased, :listing, :in_transaction, :completed_transaction]
-  before_action :get_user_purchase_products, only: [:purchase, :purchased]
+  before_action :get_user_purchase_products, only: [:purchase, :purchased, :index]
   before_action :get_user_params, only: [:index, :identification, :profile]
 
   def index

--- a/app/views/mypages/completed_transaction.html.haml
+++ b/app/views/mypages/completed_transaction.html.haml
@@ -3,14 +3,20 @@
 .main-body
   = render partial: 'shared/mypage/side_menu'
   .mypage-main
-    .mypage-main-bottom
+    .mypage-main-top
       .bought-product-header
         %p 出品した商品
       .tabs
         %ul.tabs-lists
-          %li.tabs-list.tabs-list__past-trading 出品中
-          %li.tabs-list.tabs-list__past-trading 取引中
-          %li.tabs-list.tabs-list__in-transaction 売却済み
+          %li.tabs-list.tabs-list__past-trading
+            = link_to listing_mypage_path(current_user) do
+              %h3.tabs-list__name 出品中
+          %li.tabs-list.tabs-list__past-trading
+            = link_to in_transaction_mypage_path(current_user) do
+              %h3.tabs-list__name 取引中
+          %li.tabs-list.tabs-list__in-transaction
+            = link_to completed_transaction_mypage_path(current_user) do
+              %h3.tabs-list__name 売却済み
       .tabs-contents
         - if @posts.present?
           - @posts.each do |post|

--- a/app/views/mypages/in_transaction.html.haml
+++ b/app/views/mypages/in_transaction.html.haml
@@ -3,14 +3,20 @@
 .main-body
   = render partial: 'shared/mypage/side_menu'
   .mypage-main
-    .mypage-main-bottom
+    .mypage-main-top
       .bought-product-header
         %p 出品した商品
       .tabs
         %ul.tabs-lists
-          %li.tabs-list.tabs-list__past-trading 出品中
-          %li.tabs-list.tabs-list__in-transaction 取引中
-          %li.tabs-list.tabs-list__past-trading 売却済み
+          %li.tabs-list.tabs-list__past-trading
+            = link_to listing_mypage_path(current_user) do
+              %h3.tabs-list__name 出品中
+          %li.tabs-list.tabs-list__in-transaction
+            = link_to in_transaction_mypage_path(current_user) do
+              %h3.tabs-list__name 取引中
+          %li.tabs-list.tabs-list__past-trading
+            = link_to completed_transaction_mypage_path(current_user) do
+              %h3.tabs-list__name 売却済み
       .tabs-contents
         - if @posts.present?
           - @posts.each do |post|

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -9,12 +9,16 @@
   .mypage-main
     .mypage-main-top
       .user-header
-        = link_to '/' do
+        = link_to '#' do
           .user-info-box
-            .user-info-box__thumbnail
-              = image_tag 'mypage/user-icon.png', size: '60x60', alt: 'thumbnail'
+            - if @user.avatar.present?
+              .user-info-box__thumbnail
+                = image_tag @user.avatar.url, size: '60x60', alt: 'thumbnail'
+            - else
+              .user-info-box__thumbnail
+                = image_tag 'mypage/user-icon.png', size: '60x60', alt: 'thumbnail'
             .user-info-box__user-name
-              ユーザーネーム
+              = @user.nickname
             .user-info-box__short-info
               .user-evaluation
                 %p.user-evaluation__text 評価
@@ -25,8 +29,12 @@
 
       .tabs
         %ul.tabs-lists
-          %li.tabs-list.tabs-list__news お知らせ
-          %li.tabs-list.tabs-list__to-do-list やることリスト
+          %li.tabs-list.tabs-list__news
+            = link_to '#' do
+              %h3.tabs-list__name お知らせ
+          %li.tabs-list.tabs-list__to-do-list 
+            = link_to '#' do
+              %h3.tabs-list__name やることリスト
       .tabs-contents
         -# お知らせ一覧。タブ切り替えで表示・非表示を切り替え。マイページにアクセスした段階ではこの一覧が表示されている。
         %ul.contents-lists
@@ -92,30 +100,37 @@
         %p 購入した商品
       .tabs
         %ul.tabs-lists
-          %li.tabs-list.tabs-list__in-transaction 取引中
-          %li.tabs-list.tabs-list__past-trading 過去の取引
+          %li.tabs-list.tabs-list__in-transaction
+            = link_to '#' do
+              %h3.tabs-list__name 取引中
+          %li.tabs-list.tabs-list__past-trading
+            = link_to '#' do
+              %h3.tabs-list__name 過去の取引
       .tabs-contents
         -# 取引中の商品一覧。タブ切り替えで表示・非表示を切り替え。マイページにアクセスした段階ではこの一覧が表示されている。
-        %ul.contents-lists
-          -# 最大表示件数 5件
-          %li.contents-list
-            = link_to '#' do
-              .contents-list-
-                = image_tag 'mypage/user-transaction.jpg', size: '48x48', alt: 'product-image'
-              .contents-list-main
-                .contents-list-main__top
-                  「xxxxxxxxxx」の取引中です。
-              .list-arrow-icon
-                = icon('fas', 'chevron-right')
-          %li.move-list-link
-            = link_to '#' do
-              .move-list-link__box.move-list-link__box--in-transaction
-                一覧を見る
-
-        -# 取引中の商品がない場合に表示
-        -# %ul.no-content-list
-        -#   .no-content-box
-        -#     %li.no-content-box__message.no-content-box__message--in-transaction 取引中の商品がありません
+        - if @products.present?
+          - @products.each do |product|
+            - if product.post.product_status == "completed_transaction"
+              - image = get_image_url(product.post_id)
+              %ul.contents-lists
+                -# 最大表示件数 5件
+                %li.contents-list
+                  = link_to '#' do
+                    .contents-list-
+                      = image_tag 'mypage/user-transaction.jpg', size: '48x48', alt: 'product-image'
+                    .contents-list-main
+                      .contents-list-main__top
+                        「xxxxxxxxxx」の取引中です。
+                    .list-arrow-icon
+                      = icon('fas', 'chevron-right')
+                %li.move-list-link
+                  = link_to '#' do
+                    .move-list-link__box.move-list-link__box--in-transaction
+                      一覧を見る
+        - else
+          %ul.no-content-list
+            .no-content-box
+              %li.no-content-box__message.no-content-box__message--in-transaction 取引中の商品がありません
 
         -# 過去の取引一覧。タブ切り替えで表示非表示を切り替え。
         -# %ul.contents-lists

--- a/app/views/mypages/index.html.haml
+++ b/app/views/mypages/index.html.haml
@@ -120,7 +120,7 @@
                       = image_tag 'mypage/user-transaction.jpg', size: '48x48', alt: 'product-image'
                     .contents-list-main
                       .contents-list-main__top
-                        「xxxxxxxxxx」の取引中です。
+                        = "「#{product.post.product_name}」の取引中です。"
                     .list-arrow-icon
                       = icon('fas', 'chevron-right')
                 %li.move-list-link

--- a/app/views/mypages/listing.html.haml
+++ b/app/views/mypages/listing.html.haml
@@ -3,14 +3,20 @@
 .main-body
   = render partial: 'shared/mypage/side_menu'
   .mypage-main
-    .mypage-main-bottom
+    .mypage-main-top
       .bought-product-header
         %p 出品した商品
       .tabs
         %ul.tabs-lists
-          %li.tabs-list.tabs-list__in-transaction 出品中
-          %li.tabs-list.tabs-list__past-trading 取引中
-          %li.tabs-list.tabs-list__past-trading 売却済み
+          %li.tabs-list.tabs-list__in-transaction
+            = link_to listing_mypage_path(current_user) do
+              %h3.tabs-list__name 出品中
+          %li.tabs-list.tabs-list__past-trading
+            = link_to in_transaction_mypage_path(current_user) do
+              %h3.tabs-list__name 取引中
+          %li.tabs-list.tabs-list__past-trading
+            = link_to completed_transaction_mypage_path(current_user) do
+              %h3.tabs-list__name 売却済み
       .tabs-contents
         - if @posts.present?
           - @posts.each do |post|

--- a/app/views/mypages/purchase.html.haml
+++ b/app/views/mypages/purchase.html.haml
@@ -3,13 +3,17 @@
 .main-body
   = render partial: 'shared/mypage/side_menu'
   .mypage-main
-    .mypage-main-bottom
+    .mypage-main-top
       .bought-product-header
         %p 購入した商品
       .tabs
         %ul.tabs-lists
-          %li.tabs-list.tabs-list__in-transaction 取引中
-          %li.tabs-list.tabs-list__past-trading 過去の取引
+          %li.tabs-list.tabs-list__in-transaction
+            = link_to purchase_mypage_path(current_user) do
+              %h3.tabs-list__name 取引中
+          %li.tabs-list.tabs-list__past-trading
+            = link_to purchased_mypage_path(current_user) do
+              %h3.tabs-list__name 過去の取引
       .tabs-contents
         - if @products.present?
           - @products.each do |product|

--- a/app/views/mypages/purchased.html.haml
+++ b/app/views/mypages/purchased.html.haml
@@ -3,13 +3,17 @@
 .main-body
   = render partial: 'shared/mypage/side_menu'
   .mypage-main
-    .mypage-main-bottom
+    .mypage-main-top
       .bought-product-header
         %p 購入した商品
       .tabs
         %ul.tabs-lists
-          %li.tabs-list.tabs-list__past-trading 取引中
-          %li.tabs-list.tabs-list__in-transaction 過去の取引
+          %li.tabs-list.tabs-list__past-trading
+            = link_to purchase_mypage_path(current_user) do
+              %h3.tabs-list__name 取引中
+          %li.tabs-list.tabs-list__in-transaction
+            = link_to purchased_mypage_path(current_user) do
+              %h3.tabs-list__name 過去の取引
       .tabs-contents
         - if @products.present?
           - @products.each do |product|

--- a/app/views/shared/mypage/_side_menu.html.haml
+++ b/app/views/shared/mypage/_side_menu.html.haml
@@ -2,7 +2,7 @@
   .main-menu
     %ul.menu-lists
       %li.menu-list
-        = link_to '#', class: 'menu-link' do
+        = link_to mypage_path(current_user), class: 'menu-link' do
           .menu-text
             マイページ
           .list-arrow-icon


### PR DESCRIPTION
# What
## マイページのビューの修正
[![Image from Gyazo](https://i.gyazo.com/58ecb6cc7126fecc6a626272788d810d.gif)](https://gyazo.com/58ecb6cc7126fecc6a626272788d810d)
- aタグ内の文字の色を修正
- サムネイルの下にユーザーのニックネームが表示されるように修正
- タブの部分にaタグを埋め込み
- 取引中の商品の表示を、購入した商品がある場合とない場合で条件分岐
- ユーザーのサムネイルを、ユーザーがアバターを登録している場合としていない場合で条件分岐

## マークアップ変更に伴い、同一スタイル適用箇所を修正
- マイページのタブ部分のマークアップ変更に伴い、同じスタイルを適用している箇所を修正
- タブの部分にリンクを設定
[![Image from Gyazo](https://i.gyazo.com/fbd92263f386b3a70e17f51552608212.gif)](https://gyazo.com/fbd92263f386b3a70e17f51552608212)

# Why
- マイページのビューが崩れていたため
- マイページにユーザーの情報を表示できるようにするため