### PR TITLE
Add selected option to collection_select in address registration page

### DIFF
--- a/app/views/address/_address.html.haml
+++ b/app/views/address/_address.html.haml
@@ -12,7 +12,7 @@
       .form-group__address-register__label
         = f.label '都道府県', class: 'form-group__address'
         %span.form-group__required--address 必須
-      =f.collection_select :prefecture_id, Prefecture.all, :id, :name
+      =f.collection_select :prefecture_id, Prefecture.all, :id, :name, selected: @address.prefecture_id
       = render partial: 'shared/user_registration/error', locals: { key: "prefecture"}
     .form-group__address-register
       .form-group__address-register__label


### PR DESCRIPTION
# What
住所登録の際、バリデーションエラーでリダイレクトしてきた時に、入力されていた値をデフォルト値にしていましたが、都道府県のところだけ設定が抜けていたため修正しました。

# Why
ユーザーにもう一度都道府県を選択してもらうという手間を省くため