### PR TITLE
modify sold posts status

### DIFF
--- a/app/views/shared/posts/show/_buy_button.html.haml
+++ b/app/views/shared/posts/show/_buy_button.html.haml
@@ -1,6 +1,7 @@
 - unless post.user_id == current_user.id
-  .post-content__order-box
-    = link_to '購入画面に進む', transaction_post_path(post), {class: "order-btn"}
-  - if post.product_status == "in_transaction" || post.product_status == "completed_transaction"
+  - if post.product_status == "listing"
     .post-content__order-box
-      .sold-btn 売り切れました
+      = link_to '購入画面に進む', transaction_post_path(post), {class: "order-btn"}
+- if post.product_status == "in_transaction" || post.product_status == "completed_transaction"
+  .post-content__order-box
+    .sold-btn 売り切れました

--- a/app/views/shared/posts/show/_edit-box.html.haml
+++ b/app/views/shared/posts/show/_edit-box.html.haml
@@ -1,7 +1,8 @@
 - if post.user_id == current_user.id
   .edit-content
-    = link_to '商品の編集', edit_post_path(post), class: 'edit-btn'
-    %p or
+    - if post.product_status == "listing" || post.product_status == "stopping_listing"
+      = link_to '商品の編集', edit_post_path(post), class: 'edit-btn'
+      %p or
     = form_for(post) do |f|
       - if post.product_status == "listing"
         = f.text_field :product_status, value: 'stopping_listing', class: 'hidden-field'


### PR DESCRIPTION
# WHAT
商品詳細ページの表示を修正した。
- SOLD商品のページに購入ボタンが表示されないよう修正
- 「売り切れました」表示を自分が出品した商品にも表示されるよう修正

# WHY
画面展開改善のため。
[![Image from Gyazo](https://i.gyazo.com/05777b31cc1bbda2ec103a526967fe24.png)](https://gyazo.com/05777b31cc1bbda2ec103a526967fe24)