### PR TITLE
delete _pankuzu.html.haml

### DIFF
--- a/app/views/shared/_pankuzu.html.haml
+++ b/app/views/shared/_pankuzu.html.haml
@@ -1,7 +1,0 @@
-.pankuzu-lists
-  %ul.pankuzu-lists__box
-    %li
-      = link_to 'メルカリ', root_path , {class: 'pankuzu-list'}
-      %i.fas.fa-chevron-right
-    %li.current-page
-      = post.product_name


### PR DESCRIPTION
# WHAT
仮置きで作成していたパンくずリスト部分のビューを削除

# WHY
不要なファイル整理のため。