### PR TITLE
Add flash messages

### DIFF
--- a/app/assets/javascripts/flash_messages.js
+++ b/app/assets/javascripts/flash_messages.js
@@ -1,0 +1,5 @@
+$(document).ready(function(){
+  setTimeout(function() {
+    $('.flash-messages').fadeOut( 1000 );
+  }, 2000);
+});

--- a/app/assets/stylesheets/modules/shared/pankuzu.scss
+++ b/app/assets/stylesheets/modules/shared/pankuzu.scss
@@ -35,4 +35,18 @@
 .bread {
   background-color: white;
   border-top: 1px solid #eee;
+  position: relative;
+  .flash-messages {
+    width: 100vw;
+    height: 60px;
+    text-align: center;
+    background: #cef0ce;
+    color: green;
+    font-size: 12px;
+    line-height: 60px;
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    z-index: 1;
+  }
 }

--- a/app/assets/stylesheets/modules/shared/pankuzu.scss
+++ b/app/assets/stylesheets/modules/shared/pankuzu.scss
@@ -1,37 +1,9 @@
-.pankuzu-lists {
-  height: 48px;
-  border-top: $solid_style;
-  &__box {
-    width: 1020px;
-    margin: 0 auto;
-    padding: 16px 0;
-    display: flex;
-    font-size: $links_font;
-    li {
-      .pankuzu-list {
-        color: $links_color;
-        &:hover {
-          color: $pankuzu_color;
-          @include link_underline;
-        }
-      }
-      i {
-        margin: 0 8px;
-        color: $pankuzu_color;
-      }
-    }
-    .current-page {
-      font-weight: bold;
-    }
-  }
-}
 .breadcrumbs {
   margin-left: 218px;
   // border-top: 1px solid #eee;
   height: 50px;
   padding-top: 15px;
 }
-
 .bread {
   background-color: white;
   border-top: 1px solid #eee;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :get_post, only: [:show, :edit, :update, :destroy, :transaction, :buy, :done, :card, :card_create]
+  before_action :get_post, only: [:show, :edit, :update, :destroy, :transaction, :buy, :done, :card, :card_create, :change_status]
   before_action :get_category, only: [:new, :create, :edit, :update]
 
   def index
@@ -110,6 +110,19 @@ class PostsController < ApplicationController
     end
   end
 
+  def change_status
+    if @post.update(change_status_params)
+      redirect_to @post
+      if @post.product_status == 'listing'
+        flash[:notice] = '出品を再開しました'
+      elsif @post.product_status == 'stopping_listing'
+        flash[:notice] = '出品の一旦停止をしました'
+      end
+    else
+      render @post
+    end
+  end
+
   def destroy
     if @post.destroy
       redirect_to listing_mypage_path(current_user), notice: '出品を削除しました'
@@ -201,11 +214,14 @@ class PostsController < ApplicationController
                                  :delivery_former_area,
                                  :delivery_date,
                                  :product_price,
-                                 :product_status,
                                  :user_id,
                                  :brand_name,
                                  [images_attributes: [:image, :_destroy, :id]]
                                  ).merge(user_id: current_user.id)
+  end
+
+  def change_status_params
+    params.require(:post).permit(:product_status)
   end
 
   def post_buy_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -104,7 +104,7 @@ class PostsController < ApplicationController
 
   def update
     if @post.update(update_post_params)
-      redirect_to @post
+      redirect_to @post, notice: '変更が完了しました'
     else
       render :edit
     end

--- a/app/views/mypages/listing.html.haml
+++ b/app/views/mypages/listing.html.haml
@@ -2,7 +2,7 @@
 - breadcrumb :listing
 .bread
   = breadcrumbs separator: " &rsaquo; "
-
+  = render 'shared/flash_messages'
 .main-body
   = render partial: 'shared/mypage/side_menu'
   .mypage-main

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -2,7 +2,7 @@
 - breadcrumb :show_post, @post
 .bread
   = breadcrumbs separator: " &rsaquo; "
-
+  = render 'shared/flash_messages'
 .post-container
   .post-content
     .post-content__title-box

--- a/app/views/shared/_flash_messages.html.haml
+++ b/app/views/shared/_flash_messages.html.haml
@@ -1,0 +1,3 @@
+- if flash[:notice]
+  .flash-messages
+    = flash[:notice]

--- a/app/views/shared/posts/show/_edit-box.html.haml
+++ b/app/views/shared/posts/show/_edit-box.html.haml
@@ -3,7 +3,7 @@
     - if post.product_status == "listing" || post.product_status == "stopping_listing"
       = link_to '商品の編集', edit_post_path(post), class: 'edit-btn'
       %p or
-    = form_for(post) do |f|
+    = form_with(url:change_status_post_path(post), model: post, local: true) do |f|
       - if post.product_status == "listing"
         = f.text_field :product_status, value: 'stopping_listing', class: 'hidden-field'
         = f.submit '出品を一旦停止する', class: 'stopping-listing-btn'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
       get 'search'
       get 'card'
       post 'card_create'
+      patch 'change_status'
     end
 
     collection do


### PR DESCRIPTION
# WHAT
各処理が行われた後にフラッシュメッセージが表示されるように実装した。
- 部分テンプレートの作成
- CSS,JSファイルの作成
  - CSSはパンくずのものを使用。同ファイル内未使用のスタイルは削除
- 各コントローラーにフラッシュメッセージを追加
- 商品ステータスの変更時は別アクションを使用
  - change_statusアクションとルーティングの追加
  - ストロングパラメーターの追加
  - ステータス変更ボタンをform_withに修正

# WHY
ユーザービリティ向上のため。

[![Image from Gyazo](https://i.gyazo.com/eaf074bcc08559c764c472eff05cbc04.gif)](https://gyazo.com/eaf074bcc08559c764c472eff05cbc04)