### PR TITLE
Unificate link and set flash message when complete editing user information

### DIFF
--- a/app/controllers/address_controller.rb
+++ b/app/controllers/address_controller.rb
@@ -11,12 +11,12 @@ class AddressController < ApplicationController
   end
 
   def update
-    address= Address.find(params[:id])
+    address = Address.find(params[:id])
 
     if address.update(address_params)
-      redirect_to controller: :mypages, action: :index
+      redirect_to identification_mypage_path(current_user), notice: '登録しました'
     else
-      redirect_to controller: :address, action: :identification
+      redirect_to identification_mypage_path(current_user)
     end
   end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -39,9 +39,9 @@ class ProfilesController < ApplicationController
     profile = Profile.find_by(user_id: current_user)
     address = Address.find_by(user_id: current_user)
     if profile.update(profile_delivery_params) && address.update(address_delivery_params)
-      redirect_to controller: :mypages, action: :index
+      redirect_to edit_address_delivery_profile_path, notice: '変更しました'
     else
-      redirect_to controller: :mypages, action: :profile
+      redirect_to edit_address_delivery_profile_path
     end
 
   end
@@ -50,7 +50,7 @@ class ProfilesController < ApplicationController
     user = User.find_by(id: current_user)
     
     if user.update(user_update_params) && Profile.update(profile_update_params)
-       redirect_to mypage_path
+      redirect_to profile_mypage_path, notice: '変更しました'
     else
       redirect_to profile_mypage_path
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -51,9 +51,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # PUT /resource
-  # def update
-  #   super
-  # end
+  def update
+    super
+    flash[:notice] = '変更しました'
+  end
 
   # DELETE /resource
   # def destroy
@@ -111,4 +112,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
+
+  def after_update_path_for(resource)
+    edit_user_registration_path
+  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -15,9 +15,11 @@ class Users::SessionsController < Devise::SessionsController
         redirect_to action: "new"
       else
         super
+        flash[:notice] = nil
       end
     else
       super
+      flash[:notice] = nil
     end
   end
 

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -2,6 +2,7 @@
 - breadcrumb :email_password
 .bread
   = breadcrumbs separator: " &rsaquo; "
+  = render 'shared/flash_messages'
 
 .main__container.clearfix
   = render partial: 'shared/mypage/side_menu'

--- a/app/views/mypages/identification.html.haml
+++ b/app/views/mypages/identification.html.haml
@@ -2,6 +2,7 @@
 - breadcrumb :identification
 .bread
   = breadcrumbs separator: " &rsaquo; "
+  = render 'shared/flash_messages'
 
 .main-body
   = render partial: 'shared/mypage/side_menu', locals: { user: @user }
@@ -12,7 +13,7 @@
         %h1 本人情報の登録
       -if @address.present?
         .user-registration-info__content
-          = form_with scope: 'address',url: update_address_path(@address), class: 'user-registration-info-form' do |f|
+          = form_with scope: 'address',url: update_address_path(@address), class: 'user-registration-info-form', local: true do |f|
             .user-registration-info-form__description
               %p 
                 お客様の本人情報をご登録ください。

--- a/app/views/mypages/profile.html.haml
+++ b/app/views/mypages/profile.html.haml
@@ -2,6 +2,7 @@
 - breadcrumb :profile
 .bread
   = breadcrumbs separator: " &rsaquo; "
+  = render 'shared/flash_messages'
 
 .main__container.clearfix
   = render partial: 'shared/mypage/side_menu' , locals: {user: @user}

--- a/app/views/profiles/edit_address_delivery.html.haml
+++ b/app/views/profiles/edit_address_delivery.html.haml
@@ -2,6 +2,7 @@
 - breadcrumb :edit_address_delivery
 .bread
   = breadcrumbs separator: " &rsaquo; "
+  = render 'shared/flash_messages'
 
 .main__container.clearfix
   = render partial: 'shared/mypage/side_menu', locals: { user: @user }


### PR DESCRIPTION
# What
- ユーザー情報の編集編集完了後のパスを統一
- 編集完了後のフラッシュメッセージを表示

# Why
- 動作を統一するため
- 編集が完了したことをわかりやすくするため