### PR TITLE
Modify post edit function

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -29,7 +29,8 @@ $(function () {
         var html = buildHTML('second');
         $('#category-contents').append(html);
       } else {
-        $('#post_second_category_id option:not(:first)').remove();
+        $('#post_second_category_id').empty();
+        $('#post_second_category_id').append(`<option value="">---</option>`);
       }
       children.forEach(function (child) {
         var html = buildChildren(child);
@@ -55,7 +56,8 @@ $(function () {
         var html = buildHTML('third');
         $('#category-contents').append(html);
       } else {
-        $('#post_third_category_id option:not(:first)').remove();
+        $('#post_third_category_id').empty();
+        $('#post_third_category_id').append(`<option value="">---</option>`);
       }
       grandchildren.forEach(function (grandchild) {
         var html = buildChildren(grandchild);

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -106,6 +106,8 @@ class PostsController < ApplicationController
   end
 
   def edit
+    @children = @parents.find(@post.first_category_id).children
+    @grandchildren = @children.find(@post.second_category_id).children
   end
 
   def update

--- a/app/views/shared/posts/form/_product_detail.html.haml
+++ b/app/views/shared/posts/form/_product_detail.html.haml
@@ -9,7 +9,16 @@
         .drop-down-icon
           = icon('fas', 'chevron-down')
       = render partial: 'shared/posts/form/error', locals: { post: post, key: "first_category_id"}
-      = render partial: 'shared/posts/form/error', locals: { post: post, key: "second_category_id"}
+      - if post.first_category_id.present?
+        .select__box
+          = f.collection_select :second_category_id, @children, :id, :name, {prompt: "---"}, {class: "select__box__format"}
+          .drop-down-icon
+            = icon('fas', 'chevron-down')
+        = render partial: 'shared/posts/form/error', locals: { post: post, key: "second_category_id"}
+        .select__box
+          = f.collection_select :third_category_id, @grandchildren, :id, :name, {prompt: "---"}, {class: "select__box__format"}
+          .drop-down-icon
+            = icon('fas', 'chevron-down')
     .form__content__deafult#size-content
       - if post.product_size.present?
         =f.label :product_size, "サイズ"


### PR DESCRIPTION
# WHAT
商品編集画面のカテゴリーセレクトボックスを修正した
- 子、孫カテゴリーのボックスがデフォルトで表示されるように変更

# WHY
newアクションと同じように親カテゴリのセレクトボックスしか表示されないようになっていた為。

[![Image from Gyazo](https://i.gyazo.com/2b818eb3c66ca60faed5af51b38dfb12.gif)](https://gyazo.com/2b818eb3c66ca60faed5af51b38dfb12)